### PR TITLE
EL5 Compatibility and PAM system-auth passthrough

### DIFF
--- a/files/pam.d.netatalk
+++ b/files/pam.d.netatalk
@@ -1,0 +1,7 @@
+#%PAM-1.0
+# Managed by Puppet
+# Configure netatalk to passthrough to system auth
+auth     include system-auth
+account  include system-auth
+password include system-auth
+session  include system-auth

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,7 +32,14 @@ class netatalk {
     notify  => Service[$netatalk::params::service_name],
   }
 
-  file { $netatalk::params::global_config:
+  file { '/etc/pam.d/netatalk':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '644',
+      source  => 'puppet:///modules/netatalk/pam.d.netatalk';
+  }
+
+ file { $netatalk::params::global_config:
     ensure => file,
     content => template('netatalk/netatalk.conf.erb'),
     require => Package[$netatalk::params::package_name],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,14 +1,22 @@
 class netatalk::params {
 
   $package_name = 'netatalk'
-  $service_name = 'netatalk'
+  if ($::operatingsystemrelease >= 5 and $::operatingsystemrelease < 6) {
+    $service_name = 'atalk'
+  } else {
+    $service_name = 'netatalk'
+  }
   $afp_service = true
   $afp_port    = '548'
 
   case $::operatingsystem {
 
     'centos', 'redhat', 'fedora', 'scientific': {
-      $config_dir = '/etc/netatalk'
+      if ($::operatingsystemrelease >= 5 and $::operatingsystemrelease < 6) {
+        $config_dir = '/etc/atalk'
+      } else {
+        $config_dir = '/etc/netatalk'
+      }
       $global_config = "${config_dir}/netatalk.conf"
       $volumes_config = "${config_dir}/AppleVolumes.default"
       $afpd_config = "${config_dir}/afpd.conf"


### PR DESCRIPTION
- Add operatingsystemrelease stanzas to params.pp to set service name and config dir appropriately for EL5 or EL6 distros
- Add file management for /etc/pam.d/netatalk to configure netatalk to passthrough to system-auth, allowing krb/ldap/sssd authentication of accounts to netatalk
