### PR TITLE
supporting service status on ubuntu, loosening dependency configuration

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -8,5 +8,5 @@ description ''
 project_page 'https://github.com/rcoleman/puppet-netatalk/issues'
 
 ## Add dependencies, if any:
-dependency 'ripienaar/concat', '0.x'
-dependency 'puppetlabs/stdlib', '2.x'
+dependency 'ripienaar/concat', '>= 0.1'
+dependency 'puppetlabs/stdlib', '>= 2.0'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,10 +39,23 @@ class netatalk {
     notify  => Service[$netatalk::params::service_name],
   }
 
+  case $::osfamily {
+    'ubuntu', 'debian': {
+      # check the process list for the service name to see if it's running
+      $afpd_service_has_built_in_status = false
+      $afpd_service_status_command = "ps ax | egrep -v -e 'egrep' | egrep -e 'afpd'"
+    }
+    default: {
+      $afpd_service_has_built_in_status = true
+      $afpd_service_status_command = ''
+    }
+  }
+
   service { $netatalk::params::service_name:
     ensure     => running,
     enable     => true,
-    hasstatus  => true,
+    hasstatus  => $afpd_service_has_built_in_status,
+    status     => $afpd_service_status_command,
     hasrestart => true,
   }
 


### PR DESCRIPTION
This address issue #8. Implemented service status detection for Ubuntu/Debian (for some reason this isn't supported by the system netatalk package, worked around with a shell one-liner).

Also, configured dependencies were way out of date; loosened these up for better compatibility with latest version.
