### PR TITLE
enhance shared volume default configuration

### DIFF
--- a/README
+++ b/README
@@ -33,5 +33,5 @@ Sample Usage
     volume_name = name to advertise for shared volume (string)
     options     = options for shared volume (string)
     order       = order of entry in config, relative to others.
-                  defaults to 02, main config is 01
+                  defaults to 02, main config is 00-01
 

--- a/files/AppleVolumes.default
+++ b/files/AppleVolumes.default
@@ -169,11 +169,3 @@
 #                        device number is not constant across a reboot,
 #                        cluster, ...
 #
-
-# The line below sets some DEFAULT, starting with Netatalk 2.1.
-:DEFAULT: options:upriv,usedots
-
-# By default all users have access to their home directories.
-~/			"Home Directory"
-
-# End of File

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,10 @@
 #
 # Sample Usage:
 #   include netatalk
-class netatalk {
+class netatalk(
+    $share_home_directories = true ,
+    $volume_defaults        = undef ,
+  ) {
 
   include concat::setup
   include netatalk::params
@@ -58,9 +61,29 @@ class netatalk {
     group => 'root',
   }
 
+  if $volume_defaults {
+    $_volume_defaults = $volume_defaults
+  }
+  else {
+    $_volume_defaults = $netatalk::params::volume_defaults
+  }
+  $_volume_defaults_config = "# The line below sets some DEFAULT, starting with Netatalk 2.1.\n:DEFAULT:${_volume_defaults}\n"
+
+  if $share_home_directories {
+    $_share_home_directories_config = "# By default all users have access to their home directories.\n~/			\"Home Directory\"",
+  } else {
+    $_share_home_directories_config = ''
+  }
+
   concat::fragment { 'volumes_default':
     target => $netatalk::params::volumes_config,
     source => 'puppet:///modules/netatalk/AppleVolumes.default',
+    order => '00',
+  }
+
+  concat::fragment { 'volumes_default_settings':
+    target => $netatalk::params::volumes_config,
+    content => "\n${_volume_defaults_config}\n${_share_home_directories_config}\n",
     order => '01',
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,7 +70,7 @@ class netatalk(
   $_volume_defaults_config = "# The line below sets some DEFAULT, starting with Netatalk 2.1.\n:DEFAULT:${_volume_defaults}\n"
 
   if $share_home_directories {
-    $_share_home_directories_config = "# By default all users have access to their home directories.\n~/			\"Home Directory\"",
+    $_share_home_directories_config = "# By default all users have access to their home directories.\n~/			\"Home Directory\""
   } else {
     $_share_home_directories_config = ''
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,7 @@ class netatalk::params {
   $service_name = 'netatalk'
   $afp_service = true
   $afp_port    = '548'
+  $volume_defaults = 'options:upriv,usedots'
 
   case $::operatingsystem {
 

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -8,7 +8,7 @@
 #   volume_name = name to advertise for shared volume (string)
 #   options     = options for shared volume (string)
 #   order       = order of entry in config, relative to others.
-#                 defaults to 02, main config is 01
+#                 defaults to 02, main config is 00-01
 #
 # Actions:
 #   Adds an entry to AppleVolumes.default


### PR DESCRIPTION
previously the following the shared volume default configuration details were hardcoded.
while default behavior is unchanged, the following details can now be overridden:

  sharing of all user home directories as "Home Directory" can now be turned off.

  default shared volume default configuration parameters can now be configured.
