### PR TITLE
Update dependencies on stdlib and concat

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'rcoleman-netatalk'
-version '0.1.0'
+version '0.2.0'
 source 'git://github.com/rcoleman/puppet-netatalk.git'
 author 'rcoleman'
 license 'Apache v2'
@@ -8,5 +8,5 @@ description ''
 project_page 'https://github.com/rcoleman/puppet-netatalk/issues'
 
 ## Add dependencies, if any:
-dependency 'ripienaar/concat', '0.x'
-dependency 'puppetlabs/stdlib', '2.x'
+dependency 'puppetlabs/concat', '>= 1.0.0'
+dependency 'puppetlabs/stdlib', '>= 2.0.0 <=4.1.0'


### PR DESCRIPTION
This commit updates the puppetlabs/stdlib dependency to be less
restrictive on version. It now requires anything beyond 2.x up until
4.1.x.

This commit also replaces the ripienaar/concat dependency with
puppetlabs/concat >= 1.x
