### PR TITLE
Added space to fix the issue with default options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,7 +80,7 @@ class netatalk(
   else {
     $_volume_defaults = $netatalk::params::volume_defaults
   }
-  $_volume_defaults_config = "# The line below sets some DEFAULT, starting with Netatalk 2.1.\n:DEFAULT:${_volume_defaults}\n"
+  $_volume_defaults_config = "# The line below sets some DEFAULT, starting with Netatalk 2.1.\n:DEFAULT: ${_volume_defaults}\n"
 
   if $share_home_directories {
     $_share_home_directories_config = "# By default all users have access to their home directories.\n~/			\"Home Directory\""


### PR DESCRIPTION
Default volumes options were not taken in account due to a space missing between `:DEFAULT:` tag and actual options. This commit fixes this issue.
