### PR TITLE
Update requirements to work with the latest concat/stdlib.

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -8,5 +8,5 @@ description ''
 project_page 'https://github.com/ryanycoleman/puppet-netatalk/issues'
 
 ## Add dependencies, if any:
-dependency 'puppetlabs/concat', '>= 1.0.0'
-dependency 'puppetlabs/stdlib', '>= 2.0.0 <=4.1.0'
+dependency 'puppetlabs/concat', '>= 2.1.0'
+dependency 'puppetlabs/stdlib', '>= 2.0.0 <=4.2.0'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,6 @@ class netatalk(
     $volume_defaults        = undef ,
   ) {
 
-  include concat::setup
   include netatalk::params
 
   package { $netatalk::params::package_name:


### PR DESCRIPTION
Latest concat (as of 2.1.0 https://github.com/puppetlabs/puppetlabs-concat/commit/f4241b5ffea66e69d9c51fa3ae327fdcd379013f) doesn't have concat::setup.

It (concat) also requires at least stdlib 4.2.0 (though this is not reflected in its deps ATM due to bug described in https://github.com/puppetlabs/puppetlabs-concat/pull/386). Relax the stdlib dep restriction as well.

I have tested the following configuration with my changes and it seems to work:

├── puppetlabs-concat (v2.1.0)
├── puppetlabs-stdlib (v4.11.0) 
└── rcoleman-netatalk (v0.3.0) (with this PR included)
